### PR TITLE
isInstitute query param

### DIFF
--- a/ui/src/main/webapp/picsureui/overrides/package-data-view.js
+++ b/ui/src/main/webapp/picsureui/overrides/package-data-view.js
@@ -85,7 +85,7 @@ define(['jquery',
         }
     };
     updateStatus = function(query, queryUUID, deffered, interval = 0) {
-        let queryUrlFragment = "/" + queryUUID + "/status";
+        let queryUrlFragment = "/" + queryUUID + "/status?isInstitute=true";
         query.query.expectedResultType = "SECRET_ADMIN_DATAFRAME";
         $.ajax({
             url: window.location.origin + "/picsure/query" + queryUrlFragment,
@@ -170,7 +170,7 @@ define(['jquery',
             /*
              * This will send a query to PICSURE to evaluate and execute; it will not return results.  Use downloadData to do that.
              */
-            let queryUrlFragment = '';
+            let queryUrlFragment = '?isInstitute=true';
             query.query.expectedResultType = "SECRET_ADMIN_DATAFRAME";
             return new Promise((resolve, reject) => {
                 $.ajax({


### PR DESCRIPTION
- Tell PIC-SURE that this request is to be passed to the institute node, and that the common area shouldn't try and persist or mutate the query
- This fixes a bug where queries were getting checked and 404ed by the common area